### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph= 3 color ePaper
 category=Display
 url=https://github.com/sparkfun/SparkFun_ePaper_Arduino_Library
 architectures=*
+depends=SD, SparkFun HyperDisplay


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: the Hyperdisplay dependency won't work until https://github.com/arduino/Arduino/issues/9598 is done.