### PR TITLE
Correct case of filenames in #include directives

### DIFF
--- a/src/SparkFun_ePaper_154.h
+++ b/src/SparkFun_ePaper_154.h
@@ -11,7 +11,7 @@
 */
 #ifndef SPARKFUN_EPAPER_154_H
 #define SPARKFUN_EPAPER_154_H
-#include <arduino.h>
+#include <Arduino.h>
 #include "SparkFun_ePaper.h"
 
 class EPAPER_154 : public EPAPER

--- a/src/SparkFun_ePaper_420.h
+++ b/src/SparkFun_ePaper_420.h
@@ -11,7 +11,7 @@
 */
 #ifndef SPARKFUN_EPAPER_420_H
 #define SPARKFUN_EPAPER_420_H
-#include <arduino.h>
+#include <Arduino.h>
 #include "SparkFun_ePaper.h"
 
 class EPAPER_420 : public EPAPER

--- a/src/SparkFun_ePaper_750.h
+++ b/src/SparkFun_ePaper_750.h
@@ -11,7 +11,7 @@
 */
 #ifndef SPARKFUN_EPAPER_750_H
 #define SPARKFUN_EPAPER_750_H
-#include <arduino.h>
+#include <Arduino.h>
 #include "SparkFun_ePaper.h"
 
 class EPAPER_750: public EPAPER {


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.